### PR TITLE
Add support for setting the client timeout

### DIFF
--- a/dockalot/docker.py
+++ b/dockalot/docker.py
@@ -304,7 +304,14 @@ def main():
     keep_container = args.keep_on_failure
     try:
         logger.debug("Connecting to Docker daemon")
-        docker_client = docker.from_env(version='auto')
+        to=60
+        if 'DOCKER_CLIENT_TIMEOUT' in os.environ:
+            to=int(os.environ['DOCKER_CLIENT_TIMEOUT'])
+        try:
+            docker_client = docker.from_env(version='auto', timeout=to)
+        except TypeError:
+            logger.warn("docker-py version does not support timeout parameter")
+            docker_client = docker.from_env(version='auto')
 
         pull_base_image(config, docker_client)
 


### PR DESCRIPTION
via the DOCKER_CLIENT_TIMEOUT environment variable, enabling better handling of large image creation.